### PR TITLE
CI: build an installable plugin zip on tag push (fixes broken manual installs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release plugin zip
+
+# Builds an installable emdash-exporter.zip (plugin folder at the archive
+# root, so WordPress' "Upload Plugin" accepts it) on every tag push, and as
+# a downloadable artifact on pull requests for testing.
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: PHP syntax check
+        run: |
+          find plugins/emdash-exporter -name '*.php' -print0 | xargs -0 -n1 php -l
+
+      - name: Build zip
+        run: |
+          cd plugins
+          zip -r ../emdash-exporter.zip emdash-exporter
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: emdash-exporter
+          path: emdash-exporter.zip
+
+      - name: Create release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: emdash-exporter.zip
+          generate_release_notes: true


### PR DESCRIPTION
## What does this PR do?

Fixes #6.

Users who download the repo zip from GitHub get `wp-emdash-main/plugins/emdash-exporter/...` — WordPress' **Upload Plugin** rejects that structure with no useful error, which is exactly the failure reported in #6 (the workaround in the comments is to re-zip the plugin folder manually).

This adds a small GitHub Actions workflow that removes the manual step:

- **On every `v*` tag push**: builds `emdash-exporter.zip` with the plugin folder at the archive root (the structure WordPress expects) and attaches it to a GitHub release with generated notes. The release page becomes the canonical "download the plugin here" link.
- **On pull requests**: uploads the same zip as a build artifact, so changes can be install-tested before merging.
- Runs `php -l` over all plugin files first, so a release can't ship a file with a syntax error.

No changes to the plugin itself.

Carved out of #8 so it can be reviewed and merged independently — if this lands first, #8 rebases cleanly (I'll drop the duplicate file from #8).

## Type of change

- [ ] Bug fix
- [x] CI / tooling
- [ ] New feature
- [ ] Documentation

## Testing

The zip built by the same commands (`cd plugins && zip -r ../emdash-exporter.zip emdash-exporter`) has been installed repeatedly on live WordPress sites via Plugins → Add New → Upload during the migration testing for #8.

## AI-generated code disclosure

- [x] Parts of this PR were written with AI assistance (Cursor, Claude) and reviewed by a human.